### PR TITLE
fix: resolve race condition in useBalances hook on page reload

### DIFF
--- a/react/useBalances.ts
+++ b/react/useBalances.ts
@@ -259,15 +259,16 @@ export function useBalances(
       projectId,
       user,
       connection,
-      (snapshot) => {
+      (snapshot, watchProject) => {
         if (isMountedRef.current) {
           setBalances(snapshot);
-          // If project is available, format immediately; otherwise, backfill effect will handle it
-          if (project) {
+          // Use the project from watchBalances (which internally loads it) OR the provided project prop
+          const projectToUse = watchProject || project;
+          if (projectToUse) {
             setFormatted({
-              oldToken: formatTokenAmount(snapshot.oldToken, project.oldTokenDecimals),
-              newToken: formatTokenAmount(snapshot.newToken, project.newTokenDecimals),
-              mft: formatTokenAmount(snapshot.mft, project.mftDecimals),
+              oldToken: formatTokenAmount(snapshot.oldToken, projectToUse.oldTokenDecimals),
+              newToken: formatTokenAmount(snapshot.newToken, projectToUse.newTokenDecimals),
+              mft: formatTokenAmount(snapshot.mft, projectToUse.mftDecimals),
               sol: formatTokenAmount(snapshot.sol, 9),
             });
           }

--- a/src/balances.ts
+++ b/src/balances.ts
@@ -396,7 +396,7 @@ export async function getBalances(
  * @param {string} projectId - Unique project identifier
  * @param {PublicKey} user - User wallet public key
  * @param {Connection} connection - Solana RPC connection
- * @param {(balances: BalanceSnapshot) => void} onChange - Callback for balance updates
+ * @param {(balances: BalanceSnapshot, project?: LoadedProject) => void} onChange - Callback for balance updates (receives project when loaded)
  * @param {WatchBalancesOptions} [options] - Watch options
  * @returns {UnsubscribeFn} Function to stop watching balances
  *
@@ -412,8 +412,9 @@ export async function getBalances(
  *   'my-project',
  *   userPubkey,
  *   connection,
- *   (balances) => {
+ *   (balances, project) => {
  *     console.log('Balances updated:', balances);
+ *     if (project) console.log('Project loaded:', project);
  *   },
  *   { intervalMs: 1000 } // Poll every second
  * );
@@ -426,7 +427,7 @@ export function watchBalances(
   projectId: string,
   user: PublicKey,
   connection: Connection,
-  onChange: (balances: BalanceSnapshot) => void,
+  onChange: (balances: BalanceSnapshot, project?: LoadedProject) => void,
   options: WatchBalancesOptions = {}
 ): UnsubscribeFn {
   const { intervalMs = 150, network } = options;
@@ -456,7 +457,7 @@ export function watchBalances(
         balances.mft !== lastBalances.mft
       ) {
         lastBalances = balances;
-        onChange(balances);
+        onChange(balances, loadedProject);
       }
     } catch (error) {
       // Log error but continue polling


### PR DESCRIPTION
The useBalances hook was experiencing a race condition on page reload where balances would load but formatted values would remain null because the project data wasn't available in the React component state.

Root cause:
- watchBalances internally loads the project but stores it in a local variable that isn't accessible to the React hook
- On page reload, the useBalances hook triggers with hasProject: false
- Balances arrive before the project prop is set in component state
- The formatting logic requires project decimals info, so balances display as "No balances found" even when data exists

Solution:
- Modified watchBalances to pass the loaded project to the onChange callback as a second parameter
- Updated useBalances to use the project from watchBalances OR the provided project prop, whichever is available first
- This ensures balances can be formatted immediately when they arrive, even if the component's project prop hasn't loaded yet

Resolves issue where balances would not display on page reload with projectId 'mig1' showing {hasProject: false} in console logs.