### PR TITLE
Fix: Remove problematic manual refetch logic causing wallet connection issues

### DIFF
--- a/demo/components/MigrationDemo.tsx
+++ b/demo/components/MigrationDemo.tsx
@@ -32,7 +32,7 @@ export function MigrationDemo() {
   // SDK Pattern 1: Load project configuration
   // The useLoadedProject hook automatically caches project data
   // and handles network switching between devnet/mainnet
-  const { project, isLoading: loadingProject, error: projectError, refetch: refetchProject } = useLoadedProject(
+  const { project, isLoading: loadingProject, error: projectError } = useLoadedProject(
     projectIdInput,
     connection,
     { network, enabled: !!projectIdInput }
@@ -40,7 +40,7 @@ export function MigrationDemo() {
 
   // SDK Pattern 2: Watch balances with automatic refetching
   // Balances update automatically when transactions complete
-  const { formatted, isLoading: loadingBalances, refetch: refetchBalances } = useBalances(
+  const { formatted, isLoading: loadingBalances } = useBalances(
     projectIdInput,
     wallet.publicKey,
     connection,
@@ -64,29 +64,6 @@ export function MigrationDemo() {
       }
     }
   );
-
-  // Auto-refetch project when wallet connects
-  const [didRefetchAfterConnect, setDidRefetchAfterConnect] = useState(false);
-  React.useEffect(() => {
-    if (!projectIdInput) return;
-    if (project) return;
-    if (loadingProject) return;
-    if (!wallet.publicKey) return;
-    if (didRefetchAfterConnect) return;
-    setDidRefetchAfterConnect(true);
-    refetchProject();
-  }, [wallet.publicKey, projectIdInput, project, loadingProject, didRefetchAfterConnect, refetchProject]);
-
-  // Auto-refetch balances when project loads with connected wallet
-  const [didRefetchAfterProject, setDidRefetchAfterProject] = useState(false);
-  React.useEffect(() => {
-    if (!wallet.publicKey) return;
-    if (!project) return;
-    if (!projectIdInput) return;
-    if (didRefetchAfterProject) return;
-    setDidRefetchAfterProject(true);
-    refetchBalances();
-  }, [wallet.publicKey, project, projectIdInput, didRefetchAfterProject, refetchBalances]);
 
   const handleMigrate = async () => {
     if (!project || !wallet.publicKey || !projectIdInput) {


### PR DESCRIPTION
## Summary

Fixes a critical issue where the project would not load when a wallet was connected on page reload. The problem was caused by manual refetch orchestration logic that conflicted with the SDK hooks' built-in reactivity.

## Problem

When reloading the demo page with a wallet already connected:
- Project would fail to load
- Console would show loading attempts but project would remain null
- Disconnecting the wallet would allow the project to load successfully

## Root Cause

The `MigrationDemo` component had two `useEffect` blocks with one-time state flags that were interfering with normal hook operation:

1. **`didRefetchAfterConnect` effect (lines 68-78)**:
   - Used a flag that never reset, blocking all future refetch attempts
   - Checked `if (project) return;` which prevented retries even when needed
   - Conflicted with `useLoadedProject`'s built-in reactivity

2. **`didRefetchAfterProject` effect (lines 81-89)**:
   - Similar one-time flag pattern
   - Created race conditions with balance loading
   - Unnecessary given `useBalances` already reacts to `wallet.publicKey` changes

## Solution

Removed both manual refetch effects and their associated state flags. The SDK hooks (`useLoadedProject` and `useBalances`) already handle automatic re-fetching when dependencies change:

- `useLoadedProject` re-fetches when `projectId`, `connection`, or `network` changes
- `useBalances` re-fetches when `projectId`, `user`, or `connection` changes

The manual orchestration was redundant and caused conflicts.

## Changes

- Removed `didRefetchAfterConnect` state and useEffect block
- Removed `didRefetchAfterProject` state and useEffect block  
- Removed unused `refetch` function destructuring from hook returns
- Simplified component by relying on built-in hook reactivity

## Testing

- ✅ Project loads correctly with wallet connected on reload
- ✅ Project loads correctly with wallet disconnected on reload
- ✅ Connecting wallet after page load triggers project and balance loading
- ✅ Disconnecting wallet handles gracefully
- ✅ SDK builds successfully
- ✅ Demo app builds successfully with no type errors
- ✅ All existing functionality preserved

## Impact

This simplifies the demo component by removing 25 lines of problematic code and restores proper functionality when wallets are connected during page reload.